### PR TITLE
using xarg to pass the packages to pacman or paru from a package list gives a bash error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 install_base_packages() {
-	cat ./packages/base.list | xargs sudo pacman -S -y
+  BASE_PCKG=$(cat ./packages/base.list )
+	sudo pacman -S -y $BASE_PCKG
 
 	echo "Are you using a laptop? (y/n)"
 	read -r laptop
@@ -65,14 +66,16 @@ install_aur_helper() {
 
 install_aur_packages() {
 	echo "Installing AUR packages..."
-	cat ./packages/aur.list | xargs paru -S -y
+  AUR_PCKG=$(cat ./packages/aur.list)
+  paru -S -y $AUR_PCKG 
 }
 
 install_bluetooth_packages() {
 	echo "Do you want to install bluetooth?"
 	read -r bluetooth
 	if [[ "$bluetooth" == "y" ]]; then
-		cat ./packages/bluetooth.list | xargs sudo pacman -S -y
+    BLUETOOTH_PCKG=$(cat ./packages/bluetooth.list)
+		sudo pacman -S -y $BLUETOOTH_PCKG
 		systemctl enable bluetooth
 	fi
 }

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 install_base_packages() {
-  BASE_PCKG=$(cat ./packages/base.list )
-	sudo pacman -S -y $BASE_PCKG
+	BASE_PCKG=$(cat ./packages/base.list)
+	sudo pacman -S --noconfirm $BASE_PCKG
 
 	echo "Are you using a laptop? (y/n)"
 	read -r laptop
@@ -66,16 +66,16 @@ install_aur_helper() {
 
 install_aur_packages() {
 	echo "Installing AUR packages..."
-  AUR_PCKG=$(cat ./packages/aur.list)
-  paru -S -y $AUR_PCKG 
+	AUR_PCKG=$(cat ./packages/aur.list)
+	paru -S --noconfirm $AUR_PCKG
 }
 
 install_bluetooth_packages() {
 	echo "Do you want to install bluetooth?"
 	read -r bluetooth
 	if [[ "$bluetooth" == "y" ]]; then
-    BLUETOOTH_PCKG=$(cat ./packages/bluetooth.list)
-		sudo pacman -S -y $BLUETOOTH_PCKG
+		BLUETOOTH_PCKG=$(cat ./packages/bluetooth.list)
+		sudo pacman -S --noconfirm $BLUETOOTH_PCKG
 		systemctl enable bluetooth
 	fi
 }


### PR DESCRIPTION
Hi CHris,
I used your part of your script specifically on a VM
`cat ./packages/base.list | xargs sudo pacman -S -y`

but this gives a bash error 
`command y: not found `

 instead of using xarg I used this and it worked;
```
  BASE_PCKG=$(cat ./packages/base.list )
	sudo pacman -S -y $BASE_PCKG
```
Also even tough we pass -y both pacman and paru still ask confirmation to proceed with the installation. Paru  in some cases might even ask to review the packages. 

Thanks for all the inspiration. I also installed Arch and Hyprland . Learned a lot from your streams and wanted to contribute.

Salim

